### PR TITLE
Keep empty params when building url query string

### DIFF
--- a/flymake-languagetool.el
+++ b/flymake-languagetool.el
@@ -246,7 +246,7 @@ STATUS provided from `url-retrieve'."
                   (list "language" flymake-languagetool-language)
                   (unless (string-empty-p disabled)
                     (list "disabledRules" disabled))))
-         (url-request-data (url-build-query-string params)))
+         (url-request-data (url-build-query-string params nil t)))
     (url-retrieve
      (concat (or flymake-languagetool-url
                  (format "http://localhost:%s"


### PR DESCRIPTION
I have `flymake-languagetool-load` in my markdown-mode hook, and would get the following errors when creating a new empty markdown buffer:
```
Debugger entered--Lisp error: (error "peculiar error: 400")
  signal(error ("peculiar error: 400"))
  error("peculiar error: 400")
  flymake-languagetool--handle-finished((:error (error http 400)) #<buffer test2.md<sean>> #f(compiled-function (&rest args) #<bytecode 0xcd6ba83ba4f58a7>))
  apply(flymake-languagetool--handle-finished ((:error (error http 400)) #<buffer test2.md<sean>> #f(compiled-function (&rest args) #<bytecode 0xcd6ba83ba4f58a7>)))
  url-http-activate-callback()
  url-http-content-length-after-change-function(81 123 42)
  url-http-wait-for-headers-change-function(1 127 126)
  url-http-generic-filter(#<process localhost> "HTTP/1.1 400 Bad Request\15\nDate: Sat, 13 Aug 2022 15:45:14 GMT\15\nContent-length: 41\15\n\15\nError: Missing 'text' or 'data' parameter")

```

The cause of this being the params with `text` set to `""` were being encoded as `"text&language=en-US"`. After this change, the params are encoded as `"text=&language=en-US"` (note the extra `=`), and languagetool returns a 200.