### PR TITLE
fix(flymake-languagetool.el): Address compile warnings

### DIFF
--- a/flymake-languagetool.el
+++ b/flymake-languagetool.el
@@ -31,14 +31,13 @@
 
 ;;; Code:
 
+(require 'seq)
 (require 'url)
 (require 'json)
 (require 'flymake)
 
 ;; Dynamically bound.
 (defvar url-http-end-of-headers)
-
-(autoload #'seq-map "seq")
 
 (defgroup flymake-languagetool nil
   "Flymake support for LanguageTool."
@@ -180,8 +179,8 @@ non-nil.")
                                   (lambda (rep)
                                     (car (map-values rep)))
                                   .replacements))))
-        check-list)))
-  check-list))
+              check-list)))
+    check-list))
 
 (defun flymake-languagetool--output-to-errors (output source-buffer)
   "Parse the JSON data from OUTPUT of LanguageTool. "
@@ -279,6 +278,9 @@ STATUS provided from `url-retrieve'."
                :compare (if (cl-plusp n) #'< #'>)
                :key #'overlay-start)))
     ovs))
+
+(defvar-local flymake-languagetool-current-cand nil
+  "Current overlay candidate.")
 
 (defun flymake-languagetool--ov-at-point (&optional start)
   "Return `flymake-languagetool' overlay at point."


### PR DESCRIPTION
I think there is a warning in the [compile](https://github.com/emacs-languagetool/flymake-languagetool/actions/runs/3085337758/jobs/4988513355#step:6:98) log:

```
In flymake-languagetool--ov-at-point:
flymake-languagetool.el:290:17:Warning: assignment to free variable
    ‘flymake-languagetool-current-cand’

In flymake-languagetool--suggestions:
flymake-languagetool.el:295:13:Warning: reference to free variable
    ‘flymake-languagetool-current-cand’

In flymake-languagetool--clean-overlay:
flymake-languagetool.el:305:18:Warning: reference to free variable
    ‘flymake-languagetool-current-cand’
flymake-languagetool.el:306:9:Warning: assignment to free variable
    ‘flymake-languagetool-current-cand’

In flymake-languagetool-correct-at-point:
flymake-languagetool.el:346:22:Warning: assignment to free variable
    ‘flymake-languagetool-current-cand’
flymake-languagetool.el:357:15:Warning: reference to free variable
    ‘flymake-languagetool-current-cand’
```