### PR TITLE
Upstreaming a series of improvements [v2]

### DIFF
--- a/flymake-languagetool.el
+++ b/flymake-languagetool.el
@@ -193,9 +193,6 @@ These rules will be enabled if `flymake-languagetool-check-spelling' is non-nil.
   :safe #'booleanp
   :group 'flymake-languagetool)
 
-(defvar-local flymake-languagetool--source-buffer nil
-  "Current buffer we are currently using for grammar check.")
-
 (defvar-local flymake-languagetool--proc-buf nil
   "Current process we are currently using for grammar check.")
 
@@ -328,10 +325,10 @@ STATUS provided from `url-retrieve'."
 (defun flymake-languagetool--check (report-fn text)
   "Run LanguageTool on TEXT from current buffer's contento.
 The callback function will reply with REPORT-FN."
-  (when-let ((buf flymake-languagetool--proc-buf))
+  (when-let* ((buf flymake-languagetool--proc-buf))
     ;; need to check if buffer has ongoing process or else we may
     ;; potentially delete the wrong one.
-    (when-let ((process (get-buffer-process buf)))
+    (when-let* ((process (get-buffer-process buf)))
       (delete-process process))
     (setf flymake-languagetool--proc-buf nil))
   (let* ((url-request-method "POST")
@@ -415,7 +412,6 @@ Once started call `flymake-languagetool' checker with REPORT-FN."
 
 (defun flymake-languagetool--checker (report-fn &rest _args)
   "Diagnostic checker function with REPORT-FN."
-  (setq flymake-languagetool--source-buffer (current-buffer))
   (let ((text (buffer-substring-no-properties
                (point-min) (point-max))))
     (cond
@@ -546,8 +542,8 @@ Depending on TYPE, either ignore Rule ID or Category ID."
   "Correct `flymake-languagetool' diagnostic at point.
 Use OL as diagnostic if non-nil."
   (interactive)
-  (if-let (flymake-languagetool-current-cand
-           (or ol (flymake-languagetool--ov-at-point)))
+  (if-let* ((flymake-languagetool-current-cand
+             (or ol (flymake-languagetool--ov-at-point))))
       (condition-case nil
           (when-let*
               ((ov flymake-languagetool-current-cand)
@@ -595,7 +591,7 @@ Use OL as diagnostic if non-nil."
 (defun flymake-languagetool-correct-dwim ()
   "DWIM function for correcting `flymake-languagetool' diagnostics."
   (interactive)
-  (if-let ((ov (flymake-languagetool--ov-at-point)))
+  (if-let* ((ov (flymake-languagetool--ov-at-point)))
       (funcall #'flymake-languagetool-correct-at-point ov)
     (funcall-interactively #'flymake-languagetool-correct)))
 

--- a/flymake-languagetool.el
+++ b/flymake-languagetool.el
@@ -71,8 +71,21 @@
   :group 'flymake-languagetool)
 
 (defcustom flymake-languagetool-ignore-faces-alist
-  '((org-mode . (org-code org-block))
+  '((org-mode . (org-code org-verbatim
+                          org-block font-lock-comment-face
+                          org-block-begin-line org-block-end-line
+                          org-special-keyword org-table org-tag))
+    (message-mode . (message-header-cc
+                     message-header-to
+                     message-header-other
+                     message-mml
+                     message-cited-text
+                     message-cited-text-1
+                     message-cited-text-2
+                     message-cited-text-3
+                     message-cited-text-4))
     (markdown-mode . (markdown-code-face
+                      markdown-markup-face
                       markdown-inline-code-face markdown-pre-face
                       markdown-url-face markdown-plain-url-face
                       markdown-math-face markdown-html-tag-name-face


### PR DESCRIPTION
Supersedes #31.

1. The first commit is just general cleanup: fixes some lints and removes an unused variable.
2. The second uses `json-parse-string` when available for better performance on new (29+) Emacs versions.
3. The third commit applies ignored faces to derived modes as well.
4. The fourth commit adds a few additional faces to ignore.
5. The fifth commit fixes a bug where Emoji in the buffer will cause diagnostics to be misaligned. E.g., the string "🦙🦙🦙Walk the the dog." won't underline duplicate "the" without this fix.

This PR drops two commits from #31:

1. It doesn't implement incremental checking.
2. It doesn't inform LanguageTool about what is and what isn't "markup".